### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: check
         run: cargo check
       - name: examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies]
-bevy = { version = "0.17.0-rc.1", default-features = false }
+bevy = { version = "0.17.0", default-features = false }
 
 [dev-dependencies]
 # bevy_state is needed for tests
-bevy = { version = "0.17.0-rc.1", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "bevy_state",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false }
+bevy = { version = "0.17.0-rc.1", default-features = false }
 
 [dev-dependencies]
 # bevy_state is needed for tests
-bevy = { version = "0.16.0", default-features = false, features = [
+bevy = { version = "0.17.0-rc.1", default-features = false, features = [
     "bevy_state",
 ] }
 

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -251,12 +251,10 @@ mod tests {
             for collision in &collisions {
                 if let Some((mut player, other)) =
                     players.get_either_mut_with_other(collision.0, collision.1)
-                {
-                    if let Ok(mut enemy) = enemies.get_mut(other) {
+                    && let Ok(mut enemy) = enemies.get_mut(other) {
                         player.0 -= 1;
                         enemy.0 -= 1;
                     }
-                }
             }
         }
 

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -251,10 +251,11 @@ mod tests {
             for collision in &collisions {
                 if let Some((mut player, other)) =
                     players.get_either_mut_with_other(collision.0, collision.1)
-                    && let Ok(mut enemy) = enemies.get_mut(other) {
-                        player.0 -= 1;
-                        enemy.0 -= 1;
-                    }
+                    && let Ok(mut enemy) = enemies.get_mut(other)
+                {
+                    player.0 -= 1;
+                    enemy.0 -= 1;
+                }
             }
         }
 


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.17.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_two_entities]
git = "https://github.com/rparrett/bevy_two_entities.git"
branch = "bevy-0.17"
```